### PR TITLE
Add "takeScreenshot" proc

### DIFF
--- a/src/webdriver.nim
+++ b/src/webdriver.nim
@@ -196,6 +196,13 @@ proc press*(self: Session, keys: varargs[Key]) =
 
   discard checkResponse(resp.body)
 
+proc takeScreenshot*(self: Session): string =
+  let reqUrl = $(self.driver.url / "session" / self.id / "screenshot")
+  let resp = self.driver.client.getContent(reqUrl)
+  let respObj = checkResponse(resp)
+
+  return respObj["value"].getStr()
+
 when isMainModule:
   let webDriver = newWebDriver()
   let session = webDriver.createSession()


### PR DESCRIPTION
## aboeut
I want to use [Take Screenshot](https://www.w3.org/TR/webdriver/#take-screenshot) in webdriver.
So I added `takeScreenshot` proc.

## test

I tested with the following code:
```
import webdriver, base64

var wDriver = newWebDriver()
var session = wDriver.createSession()

let testUrl = "https://www.amazon.co.uk/Nintendo-Classic-Mini-" &
                  "Entertainment-System/dp/B073BVHY3F"
session.navigate(testUrl)

let imageBase64 = takeScreenshot(session)

echo(repr(imageBase64))

writeFile("./screenshot.png", decode(imageBase64))

session.close()
```

After run the "geckodriver", I run the command `nim c -d:ssl -r test.nim`.

It created image about the page `https://www.amazon.co.uk/Nintendo-Classic-Mini-Entertainment-System/dp/B073BVHY3F`.

![screenshot](https://user-images.githubusercontent.com/8242648/55327082-40dc1880-54c4-11e9-830f-9073e3576f3e.png)

(I am nervous because it is my first pull request.)